### PR TITLE
fix issue with extracting python name

### DIFF
--- a/graphs.sh
+++ b/graphs.sh
@@ -28,7 +28,7 @@ mkdir graphs/$1
 
 for filename in data/$1/*.log; do
   if [ $PY_CHECK -eq 1 ]; then
-     name=$(echo $filename | awk -F'/' '{print $NF}' | awk -F'mem_|\.log' '{print $2}')
+     name=$(basename "$filename" .log | sed 's/^mem_//')
   else
     name=$1
   fi


### PR DESCRIPTION
Packages including 'log' would get cut and not
have their graphs generated.
Also gets rid of an awk warning about '\\.' being
treated as '.'.